### PR TITLE
#477060 ゲーム画面の降下する具材の画像を表示させ、種類を増やす

### DIFF
--- a/HamburgerGame/HamburgerGame/Food.cs
+++ b/HamburgerGame/HamburgerGame/Food.cs
@@ -11,16 +11,26 @@ namespace HamburgerGame {
         /// // 具材の座標
         /// </summary>
         public Rectangle Rectangle { get; private set; }
+        /// <summary>
+        /// 具材の画像
+        /// </summary>
+        public Image FoodImage { get; private set; }
+        /// <summary>
+        /// 具材の画像パス
+        /// </summary>
+        public string ImagePath { get; private set; }
 
         /// <summary>
         /// フードのコンストラクタ
         /// </summary>
-        /// <param name="vX">X座標</param>
-        /// <param name="vY">Y座標</param>
+        /// <param name="vPositionX">X座標</param>
+        /// <param name="vPositionY">Y座標</param>
         /// <param name="vWidth">幅</param>
         /// <param name="vHeight">高さ</param>
-        public Food(int vX, int vY, int vWidth, int vHeight) {
+        public Food(int vX, int vY, int vWidth, int vHeight, string vImage) {
             Rectangle = new Rectangle(vX, vY, vWidth, vHeight);
+            FoodImage = Image.FromFile(vImage);
+            ImagePath = vImage;
         }
 
         /// <summary>
@@ -34,7 +44,7 @@ namespace HamburgerGame {
         /// 具材を描画するメソッド
         /// </summary>
         public void Draw(Graphics g) {
-            g.FillRectangle(new SolidBrush(FFoodColor), Rectangle);
+            g.DrawImage(FoodImage, Rectangle);
         }
     }
 }

--- a/HamburgerGame/HamburgerGame/GameLogic.cs
+++ b/HamburgerGame/HamburgerGame/GameLogic.cs
@@ -8,11 +8,11 @@ namespace HamburgerGame {
         /// <summary>
         /// 具材の幅
         /// </summary>
-        private const int C_FoodWidth = 50;
+        private const int C_FoodWidth = 140;
         /// <summary>
         /// 具材の高さ
         /// </summary>
-        private const int C_FoodHeight = 50;
+        private const int C_FoodHeight = 70;
         /// <summary>
         /// 具材の落ちるスピード
         /// </summary>
@@ -41,6 +41,15 @@ namespace HamburgerGame {
         /// 描画されるPictureBox
         /// </summary>
         private PictureBox FAreaPlay;
+
+        /// <summary>
+        /// 画像パス
+        /// </summary>
+        private string FBun_TopPath = @"..\..\Image\bun_top.png";
+        private string FCheesePath = @"..\..\Image\cheese.png";
+        private string FPattyPath = @"..\..\Image\patty.png";
+        private string FLettucePath = @"..\..\Image\lettuce.png";
+        private string FTomatoPath = @"..\..\Image\tomato.png";
 
         /// <summary>
         /// ゲームロジックのコンストラクタ
@@ -88,7 +97,9 @@ namespace HamburgerGame {
         private void AddNewFood() {
             int wNewX = FRandom.Next(0, FAreaPlay.Width - C_FoodWidth);
             int wNewY = -C_FoodHeight;
-            var wNewFood = new Food(wNewX, wNewY, C_FoodWidth, C_FoodHeight);
+            string[] wImagePaths = { FBun_TopPath, FCheesePath, FPattyPath, FLettucePath, FTomatoPath };
+            string wRandomImagePath = wImagePaths[FRandom.Next(wImagePaths.Length)];
+            var wNewFood = new Food(wNewX, wNewY, C_FoodWidth, C_FoodHeight, wRandomImagePath);
             FFoodList.Add(wNewFood);
         }
 


### PR DESCRIPTION
【対応内容】
- Foodクラスにおいて、フードクラスに画像、画像パスのプロパティを追加しました。それに伴いコンストラクタも変更しました。
- GameLogicクラスにおいて、画像パスを追加し、AddNewFoodメソッド内で五種類の画像からランダムに1つ選ばれるように変更しました。また、具材のサイズを皿にあうように変更しました。

【完了基準】
- 降下する長方形の上に、具材の画像が挿入されていること
-  挿入される具材の画像が降下前に、5種類の中からランダムに選択されていること