### PR TITLE
#480448 ゲーム画面と結果画面で×ボタンを押したとき、メイン画面が表示されない

### DIFF
--- a/HamburgerGame/HamburgerGame/Form1.Designer.cs
+++ b/HamburgerGame/HamburgerGame/Form1.Designer.cs
@@ -89,6 +89,7 @@
             this.MinimizeBox = false;
             this.Name = "HamburgerGAME";
             this.Text = "ハンバーガーゲーム";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.HamburgerGAME_FormClosing);
             ((System.ComponentModel.ISupportInitialize)(this.FAreaPlay)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.FAreaDisplay)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.FPlate)).EndInit();

--- a/HamburgerGame/HamburgerGame/Form1.cs
+++ b/HamburgerGame/HamburgerGame/Form1.cs
@@ -35,31 +35,20 @@ namespace HamburgerGame {
         private void HamburgerGAME_KeyDown(object sender, KeyEventArgs e) {
             FGameLogic.ProcessKeyPress(e.KeyCode, FAreaPlay.Width);
         }
-        private void HamburgerGAME_Load_1(object sender, EventArgs e) {
-        }
 
         private void HamburgerGAME_FormClosing(object sender, FormClosingEventArgs e) {
+            // ゲームの終了処理を実行
+            FGameLogic.StopTimer();
+
             var wMainMenuForm = Application.OpenForms["MainMenu"];
 
-            // クローズ理由がユーザーによる×ボタンのクリックかどうかを確認
-            if (e.CloseReason == CloseReason.UserClosing) {
-                // 確認ダイアログを表示
-                DialogResult wResult = MessageBox.Show("MainMenuに戻ります。よろしいですか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-
-                // ダイアログの結果によって処理を分岐
-                if (wResult == DialogResult.Yes) {
-                    if (wMainMenuForm != null && wMainMenuForm is MainMenu) {
-                        wMainMenuForm.Show();
-                    } else {
-                        // エラーメッセージを表示して例外をスロー
-                        throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
-                    }
-                } else {
-                    //フォームを閉じるがキャンセルする
-                    e.Cancel = true;
-                }
+            if (wMainMenuForm == null || !(wMainMenuForm is MainMenu)) {
+                throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
             }
+
+            wMainMenuForm.Show();
         }
     }
 }
+
 

--- a/HamburgerGame/HamburgerGame/Form1.cs
+++ b/HamburgerGame/HamburgerGame/Form1.cs
@@ -44,15 +44,15 @@ namespace HamburgerGame {
             // クローズ理由がユーザーによる×ボタンのクリックかどうかを確認
             if (e.CloseReason == CloseReason.UserClosing) {
                 // 確認ダイアログを表示
-                DialogResult wResult = MessageBox.Show("MainMenuに戻りますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                DialogResult wResult = MessageBox.Show("MainMenuに戻ります。よろしいですか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
                 // ダイアログの結果によって処理を分岐
                 if (wResult == DialogResult.Yes) {
                     if (wMainMenuForm != null && wMainMenuForm is MainMenu) {
-                        wMainMenuForm.Show();                      
+                        wMainMenuForm.Show();
                     } else {
                         // エラーメッセージを表示して例外をスロー
-                        throw new Exception("メインメニューフォームが見つかりませんでした。開発者に連絡してください。");
+                        throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
                     }
                 } else {
                     //フォームを閉じるがキャンセルする

--- a/HamburgerGame/HamburgerGame/Form1.cs
+++ b/HamburgerGame/HamburgerGame/Form1.cs
@@ -37,7 +37,7 @@ namespace HamburgerGame {
         }
 
         private void HamburgerGAME_FormClosing(object sender, FormClosingEventArgs e) {
-            // ゲームの終了処理を実行
+            //ゲームタイマーを止め、タイマーを破棄
             FGameLogic.StopTimer();
 
             var wMainMenuForm = Application.OpenForms["MainMenu"];

--- a/HamburgerGame/HamburgerGame/Form1.cs
+++ b/HamburgerGame/HamburgerGame/Form1.cs
@@ -42,7 +42,7 @@ namespace HamburgerGame {
 
             var wMainMenuForm = Application.OpenForms["MainMenu"];
 
-            if (wMainMenuForm != null && wMainMenuForm is MainMenu){
+            if (wMainMenuForm is MainMenu){
                 wMainMenuForm.Show();
             } else {
                 throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");

--- a/HamburgerGame/HamburgerGame/Form1.cs
+++ b/HamburgerGame/HamburgerGame/Form1.cs
@@ -42,11 +42,11 @@ namespace HamburgerGame {
 
             var wMainMenuForm = Application.OpenForms["MainMenu"];
 
-            if (wMainMenuForm == null || !(wMainMenuForm is MainMenu)) {
+            if (wMainMenuForm != null && wMainMenuForm is MainMenu){
+                wMainMenuForm.Show();
+            } else {
                 throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
             }
-
-            wMainMenuForm.Show();
         }
     }
 }

--- a/HamburgerGame/HamburgerGame/Form1.cs
+++ b/HamburgerGame/HamburgerGame/Form1.cs
@@ -37,5 +37,29 @@ namespace HamburgerGame {
         }
         private void HamburgerGAME_Load_1(object sender, EventArgs e) {
         }
+
+        private void HamburgerGAME_FormClosing(object sender, FormClosingEventArgs e) {
+            var wMainMenuForm = Application.OpenForms["MainMenu"];
+
+            // クローズ理由がユーザーによる×ボタンのクリックかどうかを確認
+            if (e.CloseReason == CloseReason.UserClosing) {
+                // 確認ダイアログを表示
+                DialogResult wResult = MessageBox.Show("MainMenuに戻りますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                // ダイアログの結果によって処理を分岐
+                if (wResult == DialogResult.Yes) {
+                    if (wMainMenuForm != null && wMainMenuForm is MainMenu) {
+                        wMainMenuForm.Show();                      
+                    } else {
+                        // エラーメッセージを表示して例外をスロー
+                        throw new Exception("メインメニューフォームが見つかりませんでした。開発者に連絡してください。");
+                    }
+                } else {
+                    //フォームを閉じるがキャンセルする
+                    e.Cancel = true;
+                }
+            }
+        }
     }
 }
+

--- a/HamburgerGame/HamburgerGame/GameLogic.cs
+++ b/HamburgerGame/HamburgerGame/GameLogic.cs
@@ -153,7 +153,7 @@ namespace HamburgerGame {
                 // ゲーム終了時の効果音を追加する
                 new SoundPlayer(Properties.Resources.fanfare).Play();
 
-                this.ParentForm.Close();
+                this.ParentForm.Hide();
             }
         }
 

--- a/HamburgerGame/HamburgerGame/GameLogic.cs
+++ b/HamburgerGame/HamburgerGame/GameLogic.cs
@@ -144,7 +144,7 @@ namespace HamburgerGame {
 
             // 終了判定を実行
             if (FIsEnd) {
-                FTimer.Stop();
+                StopTimer();
                 //終了判定trueの時、ResultScreenに遷移する
                 var wResultScreen = new ResultScreen();
                 //終了画面を表示
@@ -312,6 +312,14 @@ namespace HamburgerGame {
         /// </summary>
         public void ProcessKeyPress(Keys key, int vAreaWidth) {
             FPlate.MovePlate(key, vAreaWidth);
+        }
+
+        /// <summary>
+        /// タイマーを停止し、タイマーを破棄するメソッド
+        /// </summary>
+        public void StopTimer() {
+            FTimer.Stop();
+            FTimer.Dispose();
         }
     }
 }

--- a/HamburgerGame/HamburgerGame/ResultScreen.Designer.cs
+++ b/HamburgerGame/HamburgerGame/ResultScreen.Designer.cs
@@ -127,6 +127,7 @@
             this.Controls.Add(this.pictureBox1);
             this.Name = "ResultScreen";
             this.Text = "ResultScreen";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ResultScreen_FormClosing);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ResultScreen_KeyDown);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();

--- a/HamburgerGame/HamburgerGame/ResultScreen.cs
+++ b/HamburgerGame/HamburgerGame/ResultScreen.cs
@@ -16,7 +16,7 @@ namespace HamburgerGame {
                     // 現在のフォームを閉じる
                     this.Close();
                 } else {// エラーメッセージを表示して例外をスロー
-                    throw new Exception("メインメニューフォームが見つかりませんでした。開発者に連絡してください。");
+                    throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
                 }
             }
         }
@@ -26,7 +26,7 @@ namespace HamburgerGame {
             var wHamburgerGAME = Application.OpenForms["HamburgerGAME"];
 
             if (wMainMenuForm == null || !(wMainMenuForm is MainMenu)) {
-                throw new Exception("メインメニューフォームが見つかりませんでした。開発者に連絡してください。");
+                throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
             }
 
             if (wHamburgerGAME == null || !(wHamburgerGAME is HamburgerGAME)) {
@@ -36,7 +36,7 @@ namespace HamburgerGame {
             // クローズ理由がユーザーによる×ボタンのクリックかどうかを確認
             if (e.CloseReason == CloseReason.UserClosing) {
                 // 確認ダイアログを表示
-                DialogResult wResult = MessageBox.Show("MainMenuに戻りますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                DialogResult wResult = MessageBox.Show("MainMenuに戻ります。よろしいですか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
                 // ダイアログの結果によって処理を分岐
                 if (wResult == DialogResult.Yes) {
@@ -48,6 +48,9 @@ namespace HamburgerGame {
                     if (wHamburgerGAME != null) {
                         wHamburgerGAME.Dispose();
                     }
+                } else {
+                    //フォームを閉じるがキャンセルする
+                    e.Cancel = true;
                 }
             }
         }

--- a/HamburgerGame/HamburgerGame/ResultScreen.cs
+++ b/HamburgerGame/HamburgerGame/ResultScreen.cs
@@ -12,12 +12,9 @@ namespace HamburgerGame {
         }
 
         private void ResultScreen_KeyDown(object sender, KeyEventArgs e) {
-            HandleEnterKeyPress();
-        }
-
-        private void HandleEnterKeyPress() {
-            var wMainMenuForm = GetOpenForm<MainMenu>("MainMenu");
-            this.Close();
+            if (e.KeyCode == Keys.Enter) {
+                this.Close();
+            }
         }
 
         private TForm GetOpenForm<TForm>(string vFormName) where TForm : Form {
@@ -35,7 +32,7 @@ namespace HamburgerGame {
             // メインメニューフォームを表示
             wMainMenuForm.Show();
             // ゲーム画面が存在する場合、フォームを閉じる
-            wHamburgerGAME?.Close();
+            wHamburgerGAME.Close();
         }
     }
 }

--- a/HamburgerGame/HamburgerGame/ResultScreen.cs
+++ b/HamburgerGame/HamburgerGame/ResultScreen.cs
@@ -5,54 +5,39 @@ namespace HamburgerGame {
     public partial class ResultScreen : Form {
         public ResultScreen() {
             InitializeComponent();
+            // キー入力をフォームが優先的に受け取るようにする
+            this.KeyPreview = true;
+            // フォームのKeyDownイベントにイベントハンドラを関連付ける
+            this.KeyDown += ResultScreen_KeyDown;
         }
-        private void ResultScreen_KeyDown(object vSender, KeyEventArgs e) {
-            var wMainMenuForm = Application.OpenForms["MainMenu"];
 
-            // Enterを押すとメインフォームを表示
-            if (e.KeyCode == Keys.Enter) {
+        private void ResultScreen_KeyDown(object sender, KeyEventArgs e) {
+            HandleEnterKeyPress();
+        }
 
-                if (wMainMenuForm != null && wMainMenuForm is MainMenu) {
-                    // 現在のフォームを閉じる
-                    this.Close();
-                } else {// エラーメッセージを表示して例外をスロー
-                    throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
-                }
+        private void HandleEnterKeyPress() {
+            var wMainMenuForm = GetOpenForm<MainMenu>("MainMenu");
+            this.Close();
+        }
+
+        private TForm GetOpenForm<TForm>(string vFormName) where TForm : Form {
+            var wForm = Application.OpenForms[vFormName];
+            if (wForm == null || !(wForm is TForm)) {
+                throw new Exception($"{typeof(TForm).Name} フォームが見つかりませんでした。フォーム名を確認してください。");
             }
-        }
+            return (TForm)wForm;
+        } 
 
         private void ResultScreen_FormClosing(object sender, FormClosingEventArgs e) {
-            var wMainMenuForm = Application.OpenForms["MainMenu"];
-            var wHamburgerGAME = Application.OpenForms["HamburgerGAME"];
+            var wMainMenuForm = GetOpenForm<MainMenu>("MainMenu");
+            var wHamburgerGAME = GetOpenForm<HamburgerGAME>("HamburgerGAME");
 
-            if (wMainMenuForm == null || !(wMainMenuForm is MainMenu)) {
-                throw new Exception("メインメニューフォームが見つかりませんでした。フォーム名を確認してください。");
-            }
-
-            if (wHamburgerGAME == null || !(wHamburgerGAME is HamburgerGAME)) {
-                throw new Exception("ハンバーガーゲームフォームが見つかりませんでした。開発者に連絡してください。");
-            }
-
-            // クローズ理由がユーザーによる×ボタンのクリックかどうかを確認
-            if (e.CloseReason == CloseReason.UserClosing) {
-                // 確認ダイアログを表示
-                DialogResult wResult = MessageBox.Show("MainMenuに戻ります。よろしいですか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-
-                // ダイアログの結果によって処理を分岐
-                if (wResult == DialogResult.Yes) {
-
-                    // メインメニューフォームを表示
-                    wMainMenuForm.Show();
-
-                    // ゲーム画面が存在する場合、破棄する
-                    if (wHamburgerGAME != null) {
-                        wHamburgerGAME.Dispose();
-                    }
-                } else {
-                    //フォームを閉じるがキャンセルする
-                    e.Cancel = true;
-                }
-            }
+            // メインメニューフォームを表示
+            wMainMenuForm.Show();
+            // ゲーム画面が存在する場合、フォームを閉じる
+            wHamburgerGAME?.Close();
         }
     }
 }
+
+

--- a/HamburgerGame/HamburgerGame/ResultScreen.cs
+++ b/HamburgerGame/HamburgerGame/ResultScreen.cs
@@ -13,12 +13,42 @@ namespace HamburgerGame {
             if (e.KeyCode == Keys.Enter) {
 
                 if (wMainMenuForm != null && wMainMenuForm is MainMenu) {
-                    wMainMenuForm.Show();
+                    // 現在のフォームを閉じる
+                    this.Close();
                 } else {// エラーメッセージを表示して例外をスロー
                     throw new Exception("メインメニューフォームが見つかりませんでした。開発者に連絡してください。");
                 }
-                // 現在のフォームを閉じる
-                this.Close();
+            }
+        }
+
+        private void ResultScreen_FormClosing(object sender, FormClosingEventArgs e) {
+            var wMainMenuForm = Application.OpenForms["MainMenu"];
+            var wHamburgerGAME = Application.OpenForms["HamburgerGAME"];
+
+            if (wMainMenuForm == null || !(wMainMenuForm is MainMenu)) {
+                throw new Exception("メインメニューフォームが見つかりませんでした。開発者に連絡してください。");
+            }
+
+            if (wHamburgerGAME == null || !(wHamburgerGAME is HamburgerGAME)) {
+                throw new Exception("ハンバーガーゲームフォームが見つかりませんでした。開発者に連絡してください。");
+            }
+
+            // クローズ理由がユーザーによる×ボタンのクリックかどうかを確認
+            if (e.CloseReason == CloseReason.UserClosing) {
+                // 確認ダイアログを表示
+                DialogResult wResult = MessageBox.Show("MainMenuに戻りますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                // ダイアログの結果によって処理を分岐
+                if (wResult == DialogResult.Yes) {
+
+                    // メインメニューフォームを表示
+                    wMainMenuForm.Show();
+
+                    // ゲーム画面が存在する場合、破棄する
+                    if (wHamburgerGAME != null) {
+                        wHamburgerGAME.Dispose();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
【対応内容】
- ゲーム画面と結果画面で×ボタンを押したとき、メイン画面に遷移するように修正しました。
- GameLogicクラスにpublicなTimerStopメソッドを追加しました。

【期待結果】
ゲーム画面、結果画面において、×ボタンを押したとき、メイン画面に戻る。